### PR TITLE
Added - HEE Support (via Config Option)

### DIFF
--- a/src/main/java/net/minecraftforge/lex/yunomakegoodmap/YUNoMakeGoodMap.java
+++ b/src/main/java/net/minecraftforge/lex/yunomakegoodmap/YUNoMakeGoodMap.java
@@ -87,7 +87,6 @@ public class YUNoMakeGoodMap
         prop.comment = "Set to true if you want to enable HEE compatibility by disabling YUNoMakeGoodMap's End changes. Requires 'overrideDefault' to be enabled.";
         disableOverrideEnd = prop.getBoolean();
 
-
         if (config.hasChanged())
         {
             config.save();

--- a/src/main/java/net/minecraftforge/lex/yunomakegoodmap/YUNoMakeGoodMap.java
+++ b/src/main/java/net/minecraftforge/lex/yunomakegoodmap/YUNoMakeGoodMap.java
@@ -39,6 +39,7 @@ public class YUNoMakeGoodMap
     private String platformType = "grass";
     private boolean generateSpikes = false;
     private boolean generateNetherFortress = false;
+    private boolean disableOverrideEnd = false;
     private Map<String, IPlatformGenerator> generators = Maps.newHashMap();
     
     @EventHandler
@@ -82,6 +83,10 @@ public class YUNoMakeGoodMap
         prop.comment = "Set to true to enable generation of the nether fortresses.";
         generateNetherFortress = prop.getBoolean(generateNetherFortress);
 
+        prop = config.get(CATEGORY_GENERAL, "disableOverrideEnd", disableOverrideEnd);
+        prop.comment = "Set to true if you want to enable HEE compatibility by disabling YUNoMakeGoodMap's End changes. Requires 'overrideDefault' to be enabled.";
+        disableOverrideEnd = prop.getBoolean();
+
 
         if (config.hasChanged())
         {
@@ -104,7 +109,8 @@ public class YUNoMakeGoodMap
         Hashtable<Integer, Class<? extends WorldProvider>> providers = ReflectionHelper.getPrivateValue(DimensionManager.class, null, "providers");
         providers.put(-1, WorldProviderHellVoid.class);
         providers.put(0,  WorldProviderSurfaceVoid.class);
-        providers.put(1,  WorldProviderEndVoid.class);
+        if (!disableOverrideEnd)
+            providers.put(1,  WorldProviderEndVoid.class);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Changes made:
- Added a simple config option to disable YUNoMakeGoodMap from overriding the End World. (Default: false)

Reasons:
- While creating a custom skyblock modpack based on using YUNoMakeGoodMap, we encountered an issue of the custom map mod and Hardcore Ender Expansion both trying to control the End dimension which resulted in a crash. By changing the bit above, we can allow compatibility between the two mods.
- We had two options of doing this: 1) The loader method, which would detect HEE and automatically make the changes. Or 2) By using a config option, they can toggle this feature on and off. I opted for the config option so that people can choose what they want to do and not force this feature on anyone. It is ultimately your mod, though, and if you want to do it via the loader method, let us know and we can send that code instead.

Thanks for your time, and hope you are doing well!