### PR TITLE
Fixed build.gradle for 1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 configurations { deployJars }
 
 apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: 'maven'
 
 version = "1.10-6.0.0"
 group= "net.minecraftforge.lex"


### PR DESCRIPTION
This makes it build on my setup.
Had to do the same to all my mods.

It fixes this error:
```
Could not find method mavenDeployer() for arguments [build_6d9caa5wwkzmp95mlyejuust$_run_closure6$_closure12@73b74615] on repository container.
```

Note that the mappings are still 1.9, but it builds.